### PR TITLE
Add explanations to the README.md and sample code files clarifying wh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Alternatively you can install from pip with:
     sudo pip install adafruit-ws2801
 
 Note that the pip install method **won't** install the example code.
+
+## Pin numbering
+
+The library (and the sample code) use the Broadcom BCM GPIO pin numbering scheme, rather than the physical pin numbering scheme. The [Adafruit T-Cobbler breakout board](https://www.adafruit.com/products/1754), for example, uses the BCM scheme. See [https://pinout.xyz](https://pinout.xyz/) for a quick-reference image.

--- a/examples/rainbow.py
+++ b/examples/rainbow.py
@@ -13,6 +13,8 @@ import Adafruit_GPIO.SPI as SPI
 # Configure the count of pixels:
 PIXEL_COUNT = 10
 
+# The WS2801 library makes use of the BCM pin numbering scheme. See the README.md for details.
+
 # Specify a software SPI connection for Raspberry Pi on the following pins:
 PIXEL_CLOCK = 18
 PIXEL_DOUT  = 23

--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -13,6 +13,8 @@ import Adafruit_GPIO.SPI as SPI
 # Configure the count of pixels:
 PIXEL_COUNT = 10
 
+# The WS2801 library makes use of the BCM pin numbering scheme. See the README.md for details.
+
 # Specify a software SPI connection for Raspberry Pi on the following pins:
 PIXEL_CLOCK = 18
 PIXEL_DOUT  = 23


### PR DESCRIPTION
Being new to using the GPIO pins on the rPi, I got confused on which pin numbering scheme (or that there were two numbering schemes at first!) was in use in the library. I've added comments to the README and example code to clarify that the library uses the BCM scheme to help the next new person using the code.
