### PR TITLE
set_pixels_rgb called the wrong function.

### DIFF
--- a/Adafruit_WS2801/WS2801.py
+++ b/Adafruit_WS2801/WS2801.py
@@ -121,7 +121,7 @@ class WS2801Pixels(object):
         change!
         """
         for i in range(self._count):
-            self.set_pixel(i, r, g, b)
+            self.set_pixel_rgb(i, r, g, b)
 
     def clear(self):
         """Clear all the pixels to black/off.  Note you MUST call show() after


### PR DESCRIPTION
- set_pixels_rgb called set_pixel instead of set_pixel_rgb.

set_pixels_rgb tried to call set_pixel. I't gave the following error:

```
>>> pixels.set_pixels_rgb(10,10,10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/proj/juleljus_backend/local/lib/python2.7/site-packages/Adafruit_WS2801/WS2801.py", line 
124, in set_pixels_rgb
    self.set_pixel(i, r, g, b)
TypeError: set_pixel() takes exactly 3 arguments (5 given)

```
